### PR TITLE
Fix seaborn package typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "nltk",
     "h5py",
     "einops",
-    "seaboard",
+    "seaborn",
     "fairscale",
     # Additional dependencies installed via Git are listed in the installation script
 ]


### PR DESCRIPTION
I believe the package seaboard does not exist, I'm guessing the package is supposed to be seaborn, so this PR is a typo fix.