### PR TITLE
Add support for Colab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "nltk",
     "h5py",
     "einops",
-    "seaboard",
+    "seaborn",
     "fairscale",
     # Additional dependencies installed via Git are listed in the installation script
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-requires-python = ">= 3.11"
+requires-python = ">= 3.10.12"
 
 dependencies = [
     "wheel",


### PR DESCRIPTION
Change pyproject.toml file to support python 3.10.12 and fix seaborn typo.